### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postgres-explorer",
   "displayName": "PgStudio (PostgreSQL Explorer)",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "PostgreSQL database explorer for VS Code with notebook support",
   "publisher": "ric-v",
   "private": false,


### PR DESCRIPTION
This pull request includes a minor update to the extension's version number in `package.json`. The version has been incremented from `0.6.9` to `0.7.0` to reflect new changes or improvements.