### PR TITLE
Nightly

### DIFF
--- a/package.json
+++ b/package.json
@@ -918,17 +918,25 @@
       {
         "command": "postgres-explorer.ddlViewer.openEditableCopy",
         "title": "DDL Viewer: Open as Editable Copy",
-        "category": "PgStudio"
+        "category": "PgStudio",
+        "icon": "$(edit)"
       },
       {
         "command": "postgres-explorer.ddlViewer.copyToClipboard",
         "title": "DDL Viewer: Copy to Clipboard",
-        "category": "PgStudio"
+        "category": "PgStudio",
+        "icon": "$(copy)"
       },
       {
         "command": "postgres-explorer.ddlViewer.executeRoutine",
         "title": "DDL Viewer: Execute Routine Scaffold",
         "category": "PgStudio"
+      },
+      {
+        "command": "postgres-explorer.ddlViewer.toggleEnabled",
+        "title": "DDL Viewer: Toggle SQL Preview",
+        "category": "PgStudio",
+        "icon": "$(file-code)"
       },
       {
         "command": "postgres-explorer.switchConnection",
@@ -1674,6 +1682,11 @@
           "type": "boolean",
           "default": true,
           "description": "Open the Definition Viewer automatically when selecting supported tree items."
+        },
+        "pgstudio.ddlViewer.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable SQL Preview (Definition Viewer) features and actions."
         }
       }
     },
@@ -1714,6 +1727,11 @@
           "group": "navigation"
         },
         {
+          "command": "postgres-explorer.ddlViewer.toggleEnabled",
+          "when": "view == postgresExplorer",
+          "group": "navigation"
+        },
+        {
           "command": "postgres-explorer.manageConnections",
           "when": "view == postgresExplorer",
           "group": "navigation"
@@ -1747,6 +1765,23 @@
           "command": "postgres-explorer.loadSavedQuery",
           "when": "view == postgresExplorer",
           "group": "2_phase7"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "postgres-explorer.ddlViewer.copyToClipboard",
+          "when": "resourceScheme == pgstudio-ddl",
+          "group": "navigation@1"
+        },
+        {
+          "command": "postgres-explorer.ddlViewer.toggleEnabled",
+          "when": "resourceScheme == pgstudio-ddl",
+          "group": "navigation@2"
+        },
+        {
+          "command": "postgres-explorer.ddlViewer.openEditableCopy",
+          "when": "resourceScheme == pgstudio-ddl",
+          "group": "navigation@3"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postgres-explorer",
   "displayName": "PgStudio (PostgreSQL Explorer)",
-  "version": "1.0.0",
+  "version": "1.0.0-nightly",
   "description": "PostgreSQL database explorer for VS Code with notebook support [Nightly]",
   "publisher": "ric-v",
   "private": false,

--- a/src/services/DdlViewerService.ts
+++ b/src/services/DdlViewerService.ts
@@ -5,6 +5,11 @@ import { ConnectionManager } from './ConnectionManager';
 import { createMetadata, getConnectionWithPassword } from '../commands/connection';
 
 const DDL_VIEWER_SCHEME = 'pgstudio-ddl';
+const DDL_VIEWER_ENABLED_CONFIG = 'pgstudio.ddlViewer.enabled';
+
+function isDdlViewerEnabled(): boolean {
+  return vscode.workspace.getConfiguration().get<boolean>(DDL_VIEWER_ENABLED_CONFIG, true);
+}
 
 type DdlObjectType =
   | 'database'
@@ -131,6 +136,13 @@ class DdlViewerCodeLensProvider implements vscode.CodeLensProvider {
 
     const codeLenses: vscode.CodeLens[] = [];
     const range = new vscode.Range(0, 0, 0, 0);
+    const isEnabled = isDdlViewerEnabled();
+
+    codeLenses.push(new vscode.CodeLens(range, {
+      title: isEnabled ? 'Disable SQL Preview' : 'Enable SQL Preview',
+      command: 'postgres-explorer.ddlViewer.toggleEnabled',
+      arguments: [!isEnabled]
+    }));
 
     codeLenses.push(new vscode.CodeLens(range, {
       title: 'Open as Editable Copy',
@@ -169,6 +181,14 @@ class DdlContentProvider implements vscode.TextDocumentContentProvider {
 
   public refresh(uri: vscode.Uri): void {
     this._onDidChange.fire(uri);
+  }
+
+  public refreshAllOpenDdlDocuments(): void {
+    for (const doc of vscode.workspace.textDocuments) {
+      if (doc.uri.scheme === DDL_VIEWER_SCHEME) {
+        this._onDidChange.fire(doc.uri);
+      }
+    }
   }
 
   public getCachedContent(uri: vscode.Uri): string | undefined {
@@ -1475,8 +1495,7 @@ export class DdlViewerService implements vscode.Disposable {
   private readonly provider = new DdlContentProvider();
   private readonly codeLensProvider = new DdlViewerCodeLensProvider();
   private readonly disposables: vscode.Disposable[] = [];
-  private ddlViewColumn: vscode.ViewColumn | undefined;
-  private initialized = false;
+  private lastPreviewTarget: DdlViewerTarget | undefined;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -1485,7 +1504,17 @@ export class DdlViewerService implements vscode.Disposable {
     this.disposables.push(
       vscode.workspace.registerTextDocumentContentProvider(DDL_VIEWER_SCHEME, this.provider),
       vscode.languages.registerCodeLensProvider({ scheme: DDL_VIEWER_SCHEME }, this.codeLensProvider),
+      vscode.workspace.onDidChangeConfiguration((event) => {
+        if (event.affectsConfiguration(DDL_VIEWER_ENABLED_CONFIG)) {
+          this.codeLensProvider.refresh();
+          this.refreshOpenPreviewDocuments();
+        }
+      }),
       this.treeView.onDidChangeSelection(async (event) => {
+        if (!isDdlViewerEnabled()) {
+          return;
+        }
+
         if (!vscode.workspace.getConfiguration().get<boolean>('pgstudio.ddlViewer.openOnSelection', true)) {
           return;
         }
@@ -1505,51 +1534,61 @@ export class DdlViewerService implements vscode.Disposable {
         }
         await this.openForItem(selected, false);
       }),
-      vscode.commands.registerCommand('postgres-explorer.ddlViewer.openEditableCopy', async (uri: vscode.Uri) => {
-        await this.openEditableCopy(uri);
+      vscode.commands.registerCommand('postgres-explorer.ddlViewer.openEditableCopy', async (uri?: vscode.Uri) => {
+        const targetUri = this.resolveDdlUri(uri);
+        if (!targetUri) {
+          vscode.window.showInformationMessage('Open a SQL Preview tab first.');
+          return;
+        }
+        await this.openEditableCopy(targetUri);
       }),
-      vscode.commands.registerCommand('postgres-explorer.ddlViewer.copyToClipboard', async (uri: vscode.Uri) => {
-        await this.copyToClipboard(uri);
+      vscode.commands.registerCommand('postgres-explorer.ddlViewer.copyToClipboard', async (uri?: vscode.Uri) => {
+        const targetUri = this.resolveDdlUri(uri);
+        if (!targetUri) {
+          vscode.window.showInformationMessage('Open a SQL Preview tab first.');
+          return;
+        }
+        await this.copyToClipboard(targetUri);
       }),
       vscode.commands.registerCommand('postgres-explorer.ddlViewer.executeRoutine', async (uri: vscode.Uri) => {
         await this.openRoutineExecuteScaffold(uri);
+      }),
+      vscode.commands.registerCommand('postgres-explorer.ddlViewer.toggleEnabled', async (forceState?: boolean) => {
+        const current = isDdlViewerEnabled();
+        const nextState = typeof forceState === 'boolean' ? forceState : !current;
+        await vscode.workspace.getConfiguration().update(DDL_VIEWER_ENABLED_CONFIG, nextState, vscode.ConfigurationTarget.Global);
+        this.codeLensProvider.refresh();
+        this.refreshOpenPreviewDocuments();
+        vscode.window.showInformationMessage(`SQL Preview ${nextState ? 'enabled' : 'disabled'}.`);
       })
     );
   }
 
   public async openForItem(item: DatabaseTreeItem, fromSelection: boolean): Promise<void> {
+    if (!isDdlViewerEnabled()) {
+      if (!fromSelection) {
+        vscode.window.showInformationMessage('SQL Preview is disabled. Enable it from settings or from a preview tab action.');
+      }
+      return;
+    }
+
     const target = this.toTarget(item);
     const uri = this.createUri(target);
-    this.provider.refresh(uri);
-    this.codeLensProvider.refresh();
+    this.lastPreviewTarget = target;
 
-    const openOptions: vscode.TextDocumentShowOptions = {
-      preserveFocus: true,
-      preview: true,
-      viewColumn: this.initialized ? this.ddlViewColumn ?? vscode.ViewColumn.Beside : vscode.ViewColumn.Beside
-    };
+    await this.provider.provideTextDocumentContent(uri);
+    this.provider.refresh(uri);
 
     const doc = await vscode.workspace.openTextDocument(uri);
-    const editor = await vscode.window.showTextDocument(doc, openOptions);
-
-    if (editor.document.languageId !== 'sql') {
-      await vscode.languages.setTextDocumentLanguage(editor.document, 'sql');
+    if (doc.languageId !== 'sql') {
+      await vscode.languages.setTextDocumentLanguage(doc, 'sql');
     }
 
-    if (!this.initialized) {
-      this.initialized = true;
-      this.ddlViewColumn = editor.viewColumn;
-    } else if (editor.viewColumn) {
-      this.ddlViewColumn = editor.viewColumn;
-    }
-
-    if (!fromSelection) {
-      await vscode.window.showTextDocument(doc, {
-        preserveFocus: true,
-        preview: true,
-        viewColumn: this.ddlViewColumn
-      });
-    }
+    await vscode.window.showTextDocument(doc, {
+      viewColumn: vscode.ViewColumn.Beside,
+      preserveFocus: fromSelection,
+      preview: fromSelection
+    });
   }
 
   public dispose(): void {
@@ -1557,6 +1596,23 @@ export class DdlViewerService implements vscode.Disposable {
       const disposable = this.disposables.pop();
       disposable?.dispose();
     }
+  }
+
+  private refreshOpenPreviewDocuments(): void {
+    this.provider.refreshAllOpenDdlDocuments();
+  }
+
+  private resolveDdlUri(uri?: vscode.Uri): vscode.Uri | undefined {
+    if (uri?.scheme === DDL_VIEWER_SCHEME) {
+      return uri;
+    }
+
+    const activeUri = vscode.window.activeTextEditor?.document.uri;
+    if (activeUri?.scheme === DDL_VIEWER_SCHEME) {
+      return activeUri;
+    }
+
+    return undefined;
   }
 
   private createUri(target: DdlViewerTarget): vscode.Uri {


### PR DESCRIPTION
This pull request introduces a new feature to enable or disable the SQL Preview (Definition Viewer) in PgStudio, along with several usability improvements and code refactoring. The main focus is on allowing users to toggle the SQL Preview functionality via settings, commands, and UI actions, as well as improving the robustness and flexibility of related commands.

**Feature: SQL Preview (Definition Viewer) Enable/Disable**

* Added a new configuration option `pgstudio.ddlViewer.enabled` to enable or disable SQL Preview features and actions. This can be toggled via settings or new UI actions.
* Introduced a new command `postgres-explorer.ddlViewer.toggleEnabled` with an associated icon, available in command palettes and context menus, allowing users to quickly enable or disable the SQL Preview. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L921-R940) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R1729-R1733) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R1770-R1786)

**Command and UI Enhancements**

* Updated the DDL Viewer commands (`openEditableCopy`, `copyToClipboard`) to work contextually with the active SQL Preview tab, improving user experience and error handling when no preview is open.
* Added CodeLens to the SQL Preview document to toggle the feature directly from the editor, reflecting the current enabled/disabled state.

**Internal Refactoring and Robustness**

* Refactored `DdlViewerService` to track the last preview target instead of using `ddlViewColumn` and `initialized` flags, simplifying logic for opening and focusing preview documents. [[1]](diffhunk://#diff-edd0bbc7bb7ab7546cffbf094d18518c95db0b5273029b17eeb0939c2ea51665L1478-R1498) [[2]](diffhunk://#diff-edd0bbc7bb7ab7546cffbf094d18518c95db0b5273029b17eeb0939c2ea51665L1508-L1553)
* Improved configuration change handling: when the SQL Preview setting changes, all open preview documents and CodeLens are refreshed to reflect the new state. [[1]](diffhunk://#diff-edd0bbc7bb7ab7546cffbf094d18518c95db0b5273029b17eeb0939c2ea51665R1507-R1517) [[2]](diffhunk://#diff-edd0bbc7bb7ab7546cffbf094d18518c95db0b5273029b17eeb0939c2ea51665R1601-R1617)
* Added utility methods to refresh all open SQL Preview documents and resolve the target URI for commands, increasing reliability and maintainability. [[1]](diffhunk://#diff-edd0bbc7bb7ab7546cffbf094d18518c95db0b5273029b17eeb0939c2ea51665R186-R193) [[2]](diffhunk://#diff-edd0bbc7bb7ab7546cffbf094d18518c95db0b5273029b17eeb0939c2ea51665R1601-R1617)

**Other**

* Updated the extension version to `1.0.0-nightly` to reflect the pre-release/nightly status.