### PR TITLE
disable payment method

### DIFF
--- a/docs/html/minimized-overview.html
+++ b/docs/html/minimized-overview.html
@@ -400,7 +400,7 @@
           <li>Early access to schema diff visual tools</li>
           <li>Direct developer feedback channel</li>
         </ul>
-        <button class="pricing-cta primary pricing-cta-pay" type="button" data-tier="sponsor">Get Sponsor</button>
+        <button class="pricing-cta primary pricing-cta-pay" type="button" data-tier="sponsor" disabled>Get Sponsor</button>
       </div>
 
       <div class="pricing-card" data-pricing-tier="singularity">
@@ -414,7 +414,7 @@
           <li>Prioritized support channel</li>
           <li>Flat org pricing — not per seat</li>
         </ul>
-        <button class="pricing-cta primary pricing-cta-pay" type="button" data-tier="singularity">Get Singularity</button>
+        <button class="pricing-cta primary pricing-cta-pay" type="button" data-tier="singularity" disabled>Get Singularity</button>
       </div>
     </div>
     <p class="pricing-activation-note" style="text-align:center;color:var(--text-muted,#9ca3af);font-size:13px;margin-top:16px">


### PR DESCRIPTION
This pull request makes a small change to the pricing section of the `docs/html/minimized-overview.html` file. The "Get Sponsor" and "Get Singularity" buttons are now disabled, preventing users from interacting with them.

* Disabled the "Get Sponsor" button for the sponsor pricing tier.
* Disabled the "Get Singularity" button for the singularity pricing tier.