### PR TITLE
disable payment

### DIFF
--- a/docs/js/checkout.js
+++ b/docs/js/checkout.js
@@ -213,7 +213,8 @@
     if (!tier || tier === 'free') return;
 
     event.preventDefault();
-    if (btn.disabled) return;
+    // Payment is disabled for now
+    return;
 
     const originalContent = btn.innerHTML;
 

--- a/docs/js/pricing.js
+++ b/docs/js/pricing.js
@@ -76,10 +76,8 @@
       if (periodEl) periodEl.textContent = parsed.period;
 
       if (payBtn) {
-        payBtn.disabled = !tierData.available;
-        payBtn.title = tierData.available
-          ? ''
-          : 'Checkout unavailable — plan not configured yet';
+        payBtn.disabled = true;
+        payBtn.title = 'Checkout disabled for now';
       }
     });
   }


### PR DESCRIPTION
This pull request temporarily disables the payment and checkout functionality in the application. The main changes ensure that users cannot initiate or complete a payment process and are informed that checkout is currently unavailable.

Payment and checkout disabling:

* [`docs/js/checkout.js`](diffhunk://#diff-43095eb3423bb5ec9cc86ec2f9ed05ef7468c24a48d5fd47b3490ad91086057eL216-R217): The event handler for the payment button now immediately returns, preventing any payment logic from running.
* [`docs/js/pricing.js`](diffhunk://#diff-57e4e2b39fbe31d27604d2acef85d568a511adeb42eccb5eb6180cf9ead36dfeL79-R80): The payment button is always disabled and displays a tooltip indicating that checkout is disabled for now.